### PR TITLE
Feat: 회원가입시 username 항상 null

### DIFF
--- a/src/main/java/com/matzipmap/mzm_memberservice/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/matzipmap/mzm_memberservice/service/impl/UserServiceImpl.java
@@ -80,7 +80,7 @@ public class UserServiceImpl extends DefaultOAuth2UserService implements UserSer
                     .email(oAuth2UserInfo.email())
                     .socialType(socialType)
                     .socialCode(socialCode)
-                    .username(oAuth2UserInfo.name())
+                    .username(null)
                     .build();
             User savedUser = userRepository.save(user);
             log.info("SavedUserId: {}", savedUser.getUserId());


### PR DESCRIPTION
- 기존 이름으로 지정 저장에서 null로 바뀜. 이유는 동명이인이 많기 때문.